### PR TITLE
Use Go port of cfscrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ Each website's scraper is an independent library that can be installed and reuse
 
 * `go get github.com/juliensalinas/torrengo/arc`
 
-The following dependencies are required if you want to be able to search/download torrent files from <http://www.yggtorrent.gg> in order to bypass the Cloudlare protection:
-
-* Python (2 or 3)
-* Python's cfscrape library (`pip install cfscrape`)
-* NodeJS
-
 ### Usage
 
 Searching "Dumas Montecristo" from all sources is as simple as:
@@ -71,4 +65,3 @@ If some sources are too slow to respond, use a timeout. For example the followin
 Some sources give both a magnet link and a torrent file (you can choose which one you want), some only give a torrent file, and some only give a magnet link.
 
 Optionally you can open the torrent file or magnet link directly in your torrent client (**Deluge**, **QBittorrent** or **Transmission** are supported for the moment).
-

--- a/core/core.go
+++ b/core/core.go
@@ -1,16 +1,15 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/laplaceon/cfbypass"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -57,62 +56,9 @@ func Fetch(url string, client *http.Client) (*http.Response, error) {
 // BypassCloudflare validates the Clouflare's Javascript challenge.
 // Once the challenge is resolved, it passes 2 new Cloudflare cookies to the client
 // so every new requests won't be challenged anymore.
-// It uses the cfscrape library in Python (https://github.com/Anorov/cloudflare-scrape).
-// Python, Nodejs, and cfscrape should be installed for this to work.
 func BypassCloudflare(url url.URL, client *http.Client) (*http.Client, error) {
-	// Build the Python script
-	pythonScript := fmt.Sprintf(
-		"import cfscrape as cs; s = cs.create_scraper(); print(s.get_cookie_string('%s', timeout=%f, headers={'user-agent': '%s'})[0])",
-		url.String(),
-		client.Timeout.Seconds(),
-		UserAgent,
-	)
-	log.WithFields(log.Fields{
-		"pythonScript": pythonScript,
-	}).Debug("Built the Python script")
-
-	// Launch Python script (-c meaning everything will be launched inline)
-	cmd := exec.Command("python3", "-c", pythonScript)
-
-	// Get the standard and error outputs
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	outStr, errStr := string(stdout.Bytes()), string(stderr.Bytes())
-	if err != nil || errStr != "" {
-		return nil, fmt.Errorf(
-			"could not get HTTP response from Python when trying to solve the Clouflare challenge: %v\n%v",
-			errStr, outStr)
-	}
-	log.WithFields(log.Fields{
-		"url":     url,
-		"cookies": outStr,
-	}).Debug("Successfully got HTTP response from Python and retrieved cookies when trying to solve the Clouflare challenge")
-
-	// Add the cookies to the client by extracting them from string.
-	// Here is a typical outStr:
-	// cf_clearance=0240fd594eaf5b4d9566a1bc9bf78699ddaac989-1550053902-10800-150; __cfduid=dba1aba9532aa1b8e75b98670c0e0eb7e1550053894
-	cookiesList := strings.Split(outStr, ";")
-	newCookie1 := &http.Cookie{
-		Name:  strings.TrimSpace(strings.Replace(strings.Split(cookiesList[0], "=")[0], "\n", "", -1)),
-		Value: strings.TrimSpace(strings.Replace(strings.Split(cookiesList[0], "=")[1], "\n", "", -1)),
-	}
-	log.WithFields(log.Fields{
-		"cookieName":  newCookie1.Name,
-		"cookieValue": newCookie1.Value,
-	}).Debug("Successfully added Clouflare cookie 1 to client")
-	newCookie2 := &http.Cookie{
-		Name:  strings.TrimSpace(strings.Replace(strings.Split(cookiesList[1], "=")[0], "\n", "", -1)),
-		Value: strings.TrimSpace(strings.Replace(strings.Split(cookiesList[1], "=")[1], "\n", "", -1)),
-	}
-	log.WithFields(log.Fields{
-		"cookieName":  newCookie2.Name,
-		"cookieValue": newCookie2.Value,
-	}).Debug("Successfully added Clouflare cookie 2 to client")
 	cookies := client.Jar.Cookies(&url)
-	cookies = append(cookies, newCookie1)
-	cookies = append(cookies, newCookie2)
+	cookies = append(cookies, cfbypass.GetTokens(url.String(), UserAgent, "")...)
 	client.Jar.SetCookies(&url, cookies)
 	log.Debug("Successfully added Clouflare cookies to client")
 


### PR DESCRIPTION
On slower computers such as first version of Raspberry Pis, launching the Python or Node virtual machine takes a non-negligible amount of time. Here, the `cfscrape` Python module is replaced by a Go port ([cfbypass](https://godoc.org/github.com/laplaceon/cfbypass)). 

This could greatly reduce the search time on some systems, and remove the Python and Node dependencies. As an example, the search time for an initial lookup on my Raspberry is almost halved (from ~5.5 seconds to ~3 seconds for the first search, and the next ones are nearly instant). Also, the code is now simpler.

What do you think ?